### PR TITLE
Restore name of loadable module, update extension category

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(MFSDA)
 #-----------------------------------------------------------------------------
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://github.com/DCBIA-OrthoLab/MFSDA_Python#readme")
-set(EXTENSION_CATEGORY "Statistics")
+set(EXTENSION_CATEGORY "Shape Analysis")
 set(EXTENSION_CONTRIBUTORS "Mateo Lopez (University of North Carolina), Juan Carlos Prieto (University of North Carolina) ")
 set(EXTENSION_DESCRIPTION "Modules for statistical shape analysis. A multivariate varying coefficient model is introduced to build the association between the multivariate shape measurements and demographic information and other clinical variables. Statistical inference, i.e., hypothesis testing, is also included in this package, which can be used in investigating whether some covariates of interest are significantly associated with the shape information. The hypothesis testing results are further used in clustering based analysis.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/DCBIA-OrthoLab/MFSDA_Python/master/MFSDA.png")

--- a/MFSDA/MFSDA.py
+++ b/MFSDA/MFSDA.py
@@ -39,7 +39,7 @@ class MFSDA(ScriptedLoadableModule):
 
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        self.parent.title = "Covariate Significance Testing" # TODO make this more human readable by adding spaces
+        self.parent.title = "MFSDA" # TODO make this more human readable by adding spaces
         self.parent.categories = ["Shape Analysis"]
         self.parent.dependencies = []
         self.parent.contributors = ["Loic Michoud"] # replace with "Firstname Lastname (Organization)"


### PR DESCRIPTION
This reverts commit 4df8b7acecc82149ce159e241881ad7d73909dd2.

MFSDA loadable module:
* The name of the loadable module is restored to `MFSDA`. it was changed to `Covariate Significance Testing`.
* The category is restored to `Pvalues`. It was changed to `Shape Analysis`

For these two CLIs, the category is restored to `Pvalues`. It was changed to `Shape Analysis.Advanced`
* MFSDA_createShapes
* MFSDA_run

## Questions

* Should we keep the name of the loadable module to `Covariate Significance Testing` ? 

* Considering that MFSDA stands for `Multivariate Functional Shape Data Analysis`, is it sensible to keep the category `Shape Analysis` (instead of reverting back to `Pvalues`)? 