### PR TITLE
ENH: Reference screenshots in extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(EXTENSION_CATEGORY "Shape Analysis")
 set(EXTENSION_CONTRIBUTORS "Mateo Lopez (University of North Carolina), Juan Carlos Prieto (University of North Carolina) ")
 set(EXTENSION_DESCRIPTION "Modules for statistical shape analysis. A multivariate varying coefficient model is introduced to build the association between the multivariate shape measurements and demographic information and other clinical variables. Statistical inference, i.e., hypothesis testing, is also included in this package, which can be used in investigating whether some covariates of interest are significantly associated with the shape information. The hypothesis testing results are further used in clustering based analysis.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/DCBIA-OrthoLab/MFSDA_Python/master/MFSDA.png")
-set(EXTENSION_SCREENSHOTURLS "")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/DCBIA-OrthoLab/MFSDA_Python/master/MFSDA/Resources/Icons/RunMFSDA.png https://raw.githubusercontent.com/DCBIA-OrthoLab/MFSDA_Python/master/MFSDA/Resources/Icons/SelectVariables.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies)
 set(EXTENSION_BUILD_SUBDIRECTORY inner-build)
 


### PR DESCRIPTION
The following images are referenced:

* SelectVariables:

![](https://raw.githubusercontent.com/DCBIA-OrthoLab/MFSDA_Python/master/MFSDA/Resources/Icons/SelectVariables.png)

* RunMFSDA:

![](https://raw.githubusercontent.com/DCBIA-OrthoLab/MFSDA_Python/master/MFSDA/Resources/Icons/RunMFSDA.png)